### PR TITLE
GEM_HOME & PATH shouldn't have a relative path

### DIFF
--- a/conf/post_deploy_actions.bash
+++ b/conf/post_deploy_actions.bash
@@ -22,7 +22,7 @@ find . -name '*.pyc' -delete
 ./manage.py migrate
 
 # Install gems in order to compile the CSS
-export GEM_HOME="../gems"
+export GEM_HOME="$(cd ../gems && pwd -P)"
 mkdir -p "$GEM_HOME"
 export PATH="$GEM_HOME/bin:$PATH"
 gem install --conservative --no-ri --no-rdoc compass zurb-foundation


### PR DESCRIPTION
This can cause confusing errors where resources packaged in gems can't
be found.
