### PR TITLE
Diary export data missing

### DIFF
--- a/diary/models.py
+++ b/diary/models.py
@@ -147,6 +147,7 @@ class ExportManager(models.Manager):
                 current_file = codecs.open( file_name, 'w', 'utf-8' )
                 current_file.write( 'user %s' % entry.user_id )
                 current_user = entry.user_id
+                current_week = 0;
 
             if current_week != entry.week.week:
                 current_file.write( '\n' )

--- a/diary/models.py
+++ b/diary/models.py
@@ -131,9 +131,6 @@ class ReminderManager(models.Manager):
 
 class ExportManager(models.Manager):
     def export_diary_text(self):
-        text_questions = [
-            'diary_impact', 'activity_diary', 'news_diary', 'local_diary'
-        ]
         entries = Entries.objects.order_by('user_id').order_by('week__week')
 
         current_user = 0;
@@ -158,11 +155,10 @@ class ExportManager(models.Manager):
                 current_file.write( '\n' )
                 current_week = entry.week.week
 
-            if entry.question in text_questions:
-                current_file.write( entry.question )
-                current_file.write( '\n-----------------------\n' )
-                current_file.write( entry.answer )
-                current_file.write( '\n\n' )
+            current_file.write( entry.question )
+            current_file.write( '\n-----------------------\n' )
+            current_file.write( entry.answer )
+            current_file.write( '\n\n' )
 
 
 

--- a/diary/models.py
+++ b/diary/models.py
@@ -131,7 +131,7 @@ class ReminderManager(models.Manager):
 
 class ExportManager(models.Manager):
     def export_diary_text(self):
-        entries = Entries.objects.order_by('user_id').order_by('week__week')
+        entries = Entries.objects.order_by('user', 'week__week')
 
         current_user = 0;
         current_week = 0;


### PR DESCRIPTION
Not sure if removing the `text_questions` filtering is really necessary, but it seemed like it was easier to generate too much information rather than not enough. This fixes the `order_by` statement in the `ExportManager` class to correctly order entries ready to be added to files. It also resets the week number when a new user is encountered so the week headings are inserted consistently.

Fixes #16 
